### PR TITLE
deviseでのaccepts_nested_attributes_forの使用について

### DIFF
--- a/backend/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,10 +1,82 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
-  private
+  
+  def create
+    super
+    # @params = parameters
+    # puts "hollow"
+    # puts params
+    # puts params[:name]
+    # puts "hollow"
 
-    def sign_up_params
-      params.permit(
-        :email, :password, :password_confirmation, :name, :patient_or_doctor, :sex,
-        patient_info_attributes: [:room_number, :phone_number, :emergency_address, :address, :bilding]
-      )
-    end
+    # puts params[:patient_profile][:room_number]
+    # @patient_profile = PatientProfile.new()
+    # @user = User.new(
+    #   name: params[:name],
+    #   email: params[:email],
+    #   password: params[:password],
+    #   password_confirmation: params[:password_confirmation],
+    #   patient_or_doctor: params[:patient_or_doctor],
+    #   sex: params[:sex]
+    # )
+    
+    
+    patient_profile = PatientProfile.new(
+      room_number: params[:patient_profile][:room_number],
+      phone_number: params[:patient_profile][:phone_number],
+      emergency_address: params[:patient_profile][:emergency_address],
+      address: params[:patient_profile][:address],
+      bilding: params[:patient_profile][:bilding],
+      user_id: resource.id
+    )
+    patient_profile.save!
+
+    # @user.save!
+    # @patient_profile = PatientProfile.new(room_number: params[:room_number],phone_number: params[:phone_number],emergency_address: params[:emergency_address],address: params[:address],bilding: params[:bilding])
+    # puts @patient_profile
+    # @patient_profile.save!
+    # render json: { 
+    #   is_login: true,
+    #   headers: { 
+    #     uid: @user.email,
+    #     client:
+    #     access_token:
+    #   }
+    #   data: {
+    #     id: @user.id,
+    #     uid: @user.email,
+    #     provider: "email",
+    #     email: @user.email,
+    #     name: @user.name,
+    #     image: @user.image,
+    #     allowPasswordChange: false,
+    #     created_at: @user.created_at,
+    #     updated_at: @user.updated_at
+    #   },
+    #       name: @user.name,
+    #       email: @user.email,
+    #       password: @user.password,
+    #       password_confirmation: @user.password_confirmation,
+    #       patient_or_doctor: @user.patient_or_doctor,
+    #       sex: @user.sex,
+    #       patient_profile: {
+    #         room_number: @user.patient_profile.room_number,
+    #         phone_number: @user.patient_profile.phone_number,
+    #         emergency_address: @user.patient_profile.emergency_address,
+    #         address: @user.patient_profile.address,
+    #         bilding: @user.patient_profile.bilding
+    #       }
+    # }
+
+
+  end
+
+  # private
+
+    # def sign_up_params
+    #   params.require(:registration).permit(
+    #     :email, :password, :password_confirmation, :name, :patient_or_doctor, :sex,
+    #     profileinfo:[:room_number, :phone_number, :emergency_address, :address, :bilding, :user_id]
+    #   )
+    #   # .merge(user_id: current_api_v1_user.id)
+    # end
 end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,6 +1,14 @@
 class ApplicationController < ActionController::Base
         include DeviseTokenAuth::Concerns::SetUserByToken
+        before_action :configure_permitted_parameters, if: :devise_controller?
 
         skip_before_action :verify_authenticity_token
         helper_method :current_user, :user_signed_in?
+
+        def configure_permitted_parameters
+                devise_parameter_sanitizer.permit(:sign_up, keys: [
+                        :email, :password, :password_confirmation, :name, :patient_or_doctor, :sex,
+                        patient_profiles_attributes:[:room_number, :phone_number, :emergency_address, :address, :bilding, :user_id]
+                        ])
+        end
 end

--- a/backend/app/models/patient_info.rb
+++ b/backend/app/models/patient_info.rb
@@ -1,3 +1,0 @@
-class PatientInfo < ApplicationRecord
-  belongs_to :user
-end

--- a/backend/app/models/patient_profile.rb
+++ b/backend/app/models/patient_profile.rb
@@ -1,0 +1,3 @@
+class PatientProfile < ApplicationRecord
+  belongs_to :user
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -7,6 +7,6 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
-  has_one :patient_info
-  accepts_nested_attributes_for :patient_info
+  has_one :patient_profile, dependent: :destroy
+  accepts_nested_attributes_for :patient_profile
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {
         registrations: 'api/v1/auth/registrations'
       }
+      
 
       namespace :auth do
         resource :sessions, only: %i[index]

--- a/backend/db/migrate/20220211014706_create_patient_profiles.rb
+++ b/backend/db/migrate/20220211014706_create_patient_profiles.rb
@@ -1,6 +1,6 @@
-class CreatePatientInfos < ActiveRecord::Migration[6.1]
+class CreatePatientProfiles < ActiveRecord::Migration[6.1]
   def change
-    create_table :patient_infos do |t|
+    create_table :patient_profiles do |t|
       t.integer :room_number
       t.string :phone_number
       t.string :emergency_address

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2022_02_11_014706) do
 
-  create_table "patient_infos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "patient_profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "room_number"
     t.string "phone_number"
     t.string "emergency_address"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2022_02_11_014706) do
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["user_id"], name: "index_patient_infos_on_user_id"
+    t.index ["user_id"], name: "index_patient_profiles_on_user_id"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -50,5 +50,5 @@ ActiveRecord::Schema.define(version: 2022_02_11_014706) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
-  add_foreign_key "patient_infos", "users"
+  add_foreign_key "patient_profiles", "users"
 end

--- a/backend/test/models/patient_info_test.rb
+++ b/backend/test/models/patient_info_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class PatientInfoTest < ActiveSupport::TestCase
+class PatientProfileTest < ActiveSupport::TestCase
   # test "the truth" do
   #   assert true
   # end

--- a/frontend/react-app/src/components/pages/SignUp.tsx
+++ b/frontend/react-app/src/components/pages/SignUp.tsx
@@ -49,7 +49,7 @@ const SignUp: React.FC = () => {
   const { setIsSignedIn, setCurrentUser } = useContext(AuthContext)
 
   // user
-  const [name, setName] = useState<string>("")
+  const [name, setName] = useState<string>("test")
   const [email, setEmail] = useState<string>("")
   const [password, setPassword] = useState<string>("")
   const [passwordConfirmation, setPasswordConfirmation] = useState<string>("")
@@ -57,18 +57,37 @@ const SignUp: React.FC = () => {
   const [sex, setSex] = useState<boolean>()
   const [alertMessageOpen, setAlertMessageOpen] = useState<boolean>(false)
   // patient
-  const [roomNumber, setRoomNumber] = useState<number>(0)
-  const [phoneNumber, setPhoneNumber] = useState<string>("")
-  const [emergencyAddress, setEmergencyAddress] = useState<string>("")
-  const [address, setAddress] = useState<string>("")
-  const [bilding, setBilding] = useState<string>("")
+  const [roomNumber, setRoomNumber] = useState<number>(8888)
+  const [phoneNumber, setPhoneNumber] = useState<string>("77778888999")
+  const [emergencyAddress, setEmergencyAddress] = useState<string>("55566667777")
+  const [address, setAddress] = useState<string>("test")
+  const [bilding, setBilding] = useState<string>("test")
 
   // ボタンの許可
   const [buttonDisAllow, setButtonDisAllow] = useState<boolean>(true)
   useEffect(() => {
-    if (patientOrDoctor === false && name !== "" && email !== "" && password !== "" && passwordConfirmation === password && sex !== undefined) {
+    if (
+      patientOrDoctor === false &&
+      name !== "" &&
+      email !== "" &&
+      password !== "" &&
+      passwordConfirmation === password &&
+      sex !== undefined
+    ) {
       setButtonDisAllow(false)
-    } else if (patientOrDoctor === true && name !== "" && email !== "" && password !== "" && passwordConfirmation === password && sex !== undefined && roomNumber !== 0 && phoneNumber !== "" && emergencyAddress !== "" && address !== "" && bilding !== "") {
+    } else if (
+      patientOrDoctor === true &&
+      name !== "" &&
+      email !== "" &&
+      password !== "" &&
+      passwordConfirmation === password &&
+      sex !== undefined &&
+      roomNumber !== 0 &&
+      phoneNumber !== "" &&
+      emergencyAddress !== "" &&
+      address !== "" &&
+      bilding !== ""
+    ) {
       setButtonDisAllow(false)
     } else {
       setButtonDisAllow(true)
@@ -78,31 +97,49 @@ const SignUp: React.FC = () => {
   const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
 
-    let params: SignUpParams | PatientParams;
+    // SignUpParams | PatientParams;
+    let params: SignUpParams;
+    // let patientProfile: PatientParams;
     if (sex !== undefined) {
       if (patientOrDoctor === true) {
         params = {
+
           name: name,
           email: email,
           password: password,
           passwordConfirmation: passwordConfirmation,
           patientOrDoctor: patientOrDoctor,
           sex: sex,
+
           // patient
-          roomNumber: roomNumber,
-          phoneNumber: phoneNumber,
-          emergencyAddress: emergencyAddress,
-          address: address,
-          bilding: bilding
+          patientProfile: {
+            roomNumber: roomNumber,
+            phoneNumber: phoneNumber,
+            emergencyAddress: emergencyAddress,
+            address: address,
+            bilding: bilding
+          }
+
         }
       } else if (patientOrDoctor === false) {
         params = {
+
           name: name,
           email: email,
           password: password,
           passwordConfirmation: passwordConfirmation,
           patientOrDoctor: patientOrDoctor,
-          sex: sex
+          sex: sex,
+
+          // patient
+          patientProfile: {
+            roomNumber: roomNumber,
+            phoneNumber: phoneNumber,
+            emergencyAddress: emergencyAddress,
+            address: address,
+            bilding: bilding
+          }
+
         }
       } else {
         return
@@ -217,6 +254,7 @@ const SignUp: React.FC = () => {
                   label="部屋番号"
                   value={roomNumber === 0 ? '' : roomNumber}
                   margin="dense"
+                  inputProps={{ maxLength: 4, pattern: "^[0-9_]+$" }}
                   onChange={event => setRoomNumber(inputValid(Number(event.target.value)))}
                 />
                 <TextField
@@ -226,6 +264,7 @@ const SignUp: React.FC = () => {
                   label="電話番号"
                   value={phoneNumber}
                   margin="dense"
+                  inputProps={{ maxLength: 11, pattern: "^[0-9_]+$" }}
                   onChange={event => setPhoneNumber(event.target.value)}
                 />
                 <TextField
@@ -235,6 +274,7 @@ const SignUp: React.FC = () => {
                   label="緊急連絡先"
                   value={emergencyAddress}
                   margin="dense"
+                  inputProps={{ maxLength: 11, pattern: "^[0-9_]+$" }}
                   onChange={event => setEmergencyAddress(event.target.value)}
                 />
                 <TextField

--- a/frontend/react-app/src/interfaces/index.ts
+++ b/frontend/react-app/src/interfaces/index.ts
@@ -1,11 +1,15 @@
 // サインアップ
 export interface SignUpParams {
+
   name: string
   email: string
   password: string
   passwordConfirmation: string
   patientOrDoctor: boolean
   sex: boolean
+  // patient
+  patientProfile: PatientParams
+
 }
 
 export interface PatientParams {


### PR DESCRIPTION
deviseでのサインアップ時にaccepts_nested_attributes_forを使用したがその場合、
createでのオーバーライドが必要。
そこにdevise token authでのtoken作成も関与してくるのでtokenの生成を自身でしないといけなくなるがそれでは
devise token authを使っている意味がなくなってしまうので良い実装をするためにも仕様の変更を行う。
具体的のは患者の追加情報はサインアップ時には入力させず、サインイン後のマイページで追加させようと思う。