### PR TITLE
buildingのタイポ修正、usersのimageカラムをpatient_profilesに移動

### DIFF
--- a/README参考資料/er図.drawio
+++ b/README参考資料/er図.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="UjBX9D1F_PHXTORusFUd" name="ページ1">
-        <mxGraphModel dx="442" dy="485" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1000" pageHeight="700" math="0" shadow="0">
+        <mxGraphModel dx="654" dy="485" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1000" pageHeight="700" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -52,7 +52,7 @@
                 <mxCell id="26" value="email: integer" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="23" vertex="1">
                     <mxGeometry y="104" width="200" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="130" value="image: image" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="23" vertex="1">
+                <mxCell id="130" value="image: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="23" vertex="1">
                     <mxGeometry y="130" width="200" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="106" value="patient_or_doctor: boolean" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="23" vertex="1">

--- a/backend/app/controllers/api/v1/patient_profiles_controller.rb
+++ b/backend/app/controllers/api/v1/patient_profiles_controller.rb
@@ -56,7 +56,7 @@ class Api::V1::PatientProfilesController < ApplicationController
   private
     def patient_profile_params
       params.require(:patient_profile).permit(
-        :room_number, :phone_number, :emergency_address, :address, :bilding, :user_id
+        :room_number, :phone_number, :emergency_address, :address, :building, :user_id
       )
     end
     def user_params

--- a/backend/app/models/patient_profile.rb
+++ b/backend/app/models/patient_profile.rb
@@ -1,11 +1,12 @@
 class PatientProfile < ApplicationRecord
+  mount_uploader :image, ImageUploader
   belongs_to :user
   with_options presence: true do
     validates :room_number, numericality: { in: 1..9999 }
     validates :phone_number, numericality: { in: 9999999999..99999999999 }
     validates :emergency_address, numericality: { in: 9999999999..99999999999 }
     validates :address, length: { in: 1..100 }
-    validates :bilding, length: { in: 1..100 }
+    validates :building, length: { in: 1..100 }
     validates :user_id
   end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -2,7 +2,6 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
-  mount_uploader :image, ImageUploader
 
   has_one :patient_profile, dependent: :destroy
   has_many :interviews, dependent: :destroy

--- a/backend/db/migrate/20220207013647_devise_token_auth_create_users.rb
+++ b/backend/db/migrate/20220207013647_devise_token_auth_create_users.rb
@@ -31,7 +31,6 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.1]
       ## User Info
       t.string :name
       # t.string :nickname
-      t.string :image
       t.string :email
       # 追加情報
       t.boolean :sex

--- a/backend/db/migrate/20220211014706_create_patient_profiles.rb
+++ b/backend/db/migrate/20220211014706_create_patient_profiles.rb
@@ -1,11 +1,12 @@
 class CreatePatientProfiles < ActiveRecord::Migration[6.1]
   def change
     create_table :patient_profiles do |t|
+      t.string :image
       t.integer :room_number
       t.string :phone_number
       t.string :emergency_address
       t.string :address
-      t.string :bilding
+      t.string :building
       t.references :user, foreign_key: true
       t.timestamps
     end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -44,11 +44,12 @@ ActiveRecord::Schema.define(version: 2022_02_16_035316) do
   end
 
   create_table "patient_profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "image"
     t.integer "room_number"
     t.string "phone_number"
     t.string "emergency_address"
     t.string "address"
-    t.string "bilding"
+    t.string "building"
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -75,7 +76,6 @@ ActiveRecord::Schema.define(version: 2022_02_16_035316) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.string "name"
-    t.string "image"
     t.string "email"
     t.boolean "sex"
     t.boolean "patient_or_doctor"
@@ -84,7 +84,6 @@ ActiveRecord::Schema.define(version: 2022_02_16_035316) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["id"], name: "id_index"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end

--- a/frontend/react-app/src/interfaces/index.ts
+++ b/frontend/react-app/src/interfaces/index.ts
@@ -18,7 +18,7 @@ export interface SignUpParams {
 //   phoneNumber: string
 //   emergencyAddress: string
 //   address: string
-//   bilding: string
+//   building: string
 // }
 
 // サインイン


### PR DESCRIPTION
## やったこと

*patient_profilesのbuildingカラムのタイポ修正
*usersのimageカラムをpatient_profilesに移動

## やらないこと

フロント側のタイポの影響による修正、
仕様自体が変わるので意味は修正しない。
修正はusersのサインアップ修正時に行う。

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
* 無し

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
* 無し

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？
 mysql直接確認

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
* 特になし
