### PR TITLE
Patient profiles fix

### DIFF
--- a/README参考資料/er図.drawio
+++ b/README参考資料/er図.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="UjBX9D1F_PHXTORusFUd" name="ページ1">
-        <mxGraphModel dx="654" dy="485" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1000" pageHeight="700" math="0" shadow="0">
+        <mxGraphModel dx="1002" dy="746" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1000" pageHeight="700" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -38,7 +38,7 @@
                     </mxGeometry>
                 </mxCell>
                 <mxCell id="23" value="Users/ユーザー" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;" parent="1" vertex="1">
-                    <mxGeometry x="370" y="40" width="200" height="182" as="geometry"/>
+                    <mxGeometry x="370" y="40" width="200" height="156" as="geometry"/>
                 </mxCell>
                 <mxCell id="24" value="id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="23" vertex="1">
                     <mxGeometry y="26" width="200" height="26" as="geometry"/>
@@ -52,35 +52,35 @@
                 <mxCell id="26" value="email: integer" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="23" vertex="1">
                     <mxGeometry y="104" width="200" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="130" value="image: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="23" vertex="1">
+                <mxCell id="106" value="patient_or_doctor: boolean" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="23" vertex="1">
                     <mxGeometry y="130" width="200" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="106" value="patient_or_doctor: boolean" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="23" vertex="1">
-                    <mxGeometry y="156" width="200" height="26" as="geometry"/>
-                </mxCell>
                 <mxCell id="134" value="patient_profile/患者様情報" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;" parent="1" vertex="1">
-                    <mxGeometry x="660" y="40" width="300" height="208" as="geometry"/>
+                    <mxGeometry x="660" y="40" width="300" height="234" as="geometry"/>
                 </mxCell>
                 <mxCell id="135" value="id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
                     <mxGeometry y="26" width="300" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="27" value="room_number(部屋番号): integer" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
+                <mxCell id="130" value="image: string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
                     <mxGeometry y="52" width="300" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="28" value="phone_number (電話番号): string only:number" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="134" vertex="1">
+                <mxCell id="27" value="room_number(部屋番号): integer" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
                     <mxGeometry y="78" width="300" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="73" value="emergency_address(緊急連絡先): string only:number" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
+                <mxCell id="28" value="phone_number (電話番号): string only:number" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="134" vertex="1">
                     <mxGeometry y="104" width="300" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="30" value="adress(住所): string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
+                <mxCell id="73" value="emergency_address(緊急連絡先): string only:number" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
                     <mxGeometry y="130" width="300" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="65" value="building(建物名): string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
+                <mxCell id="30" value="adress(住所): string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
                     <mxGeometry y="156" width="300" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="139" value="user_id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
+                <mxCell id="65" value="building(建物名): string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
                     <mxGeometry y="182" width="300" height="26" as="geometry"/>
+                </mxCell>
+                <mxCell id="139" value="user_id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="134" vertex="1">
+                    <mxGeometry y="208" width="300" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="141" value="Answers/回答" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;" parent="1" vertex="1">
                     <mxGeometry x="380" y="280" width="160" height="130" as="geometry"/>
@@ -126,13 +126,13 @@
                 <mxCell id="163" value="interview_id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="159" vertex="1">
                     <mxGeometry y="104" width="200" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="213" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;endArrow=ERoneToMany;endFill=0;strokeWidth=2;startArrow=ERone;startFill=0;endSize=10;startSize=10;entryX=0.497;entryY=1.21;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="164" target="146" edge="1">
+                <mxCell id="213" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;endArrow=ERoneToMany;endFill=0;strokeWidth=2;startArrow=ERone;startFill=0;endSize=10;startSize=10;entryX=0.492;entryY=1.083;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="164" target="146" edge="1">
                     <mxGeometry relative="1" as="geometry">
                         <mxPoint x="360" y="450" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
                 <mxCell id="164" value="Questions/質問" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;" parent="1" vertex="1">
-                    <mxGeometry x="380" y="520" width="160" height="104" as="geometry"/>
+                    <mxGeometry x="379" y="520" width="160" height="104" as="geometry"/>
                 </mxCell>
                 <mxCell id="165" value="id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="164" vertex="1">
                     <mxGeometry y="26" width="160" height="26" as="geometry"/>
@@ -159,7 +159,7 @@
                     </mxGeometry>
                 </mxCell>
                 <mxCell id="189" value="seed_content to Questions" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
-                    <mxGeometry x="710" y="380" width="200" height="260" as="geometry"/>
+                    <mxGeometry x="719" y="380" width="200" height="260" as="geometry"/>
                 </mxCell>
                 <mxCell id="195" value="complexion (顔色)" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="189" vertex="1">
                     <mxGeometry y="26" width="200" height="26" as="geometry"/>

--- a/backend/app/controllers/api/v1/interviews_controller.rb
+++ b/backend/app/controllers/api/v1/interviews_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::InterviewsController < ApplicationController
       interviews = Interview.all.order(created_at: :desc)
       render json: interviews
     else
-      render json: interviews.errors, status: 422
+      render json: { status: 404 }
     end
   end
 

--- a/backend/app/controllers/api/v1/patient_profiles_controller.rb
+++ b/backend/app/controllers/api/v1/patient_profiles_controller.rb
@@ -1,67 +1,36 @@
 class Api::V1::PatientProfilesController < ApplicationController
+  before_action :authenticate_api_v1_user!
+
   def show
-    if params[:patien_or_doctor] == true
-      if patient_profile = PatientProfile.find_by(user_id: params[:user_id])
-        render json: patient_profile
-      else
-        render json: patient_profile.errors, status: 422
-      end
+    if patient_profile = PatientProfile.find_by(user_id: current_api_v1_user.id)
+      render json: patient_profile
     else
-      # フロント側でユーザーのデータを持ってない場合はここに取得する処理を書く
-      render json: "user is docter"
+      render json: { status: 404 }
     end
   end
 
   def create
-    user_patient_profile = {}
-    user = User.find(user_params[:id])
-    if user.update(image: user_params[:image])
-      patient_profile = PatientProfile.new(patient_profile_params)
-      if patient_profile.save
-        user_patient_profile[:user]=user
-        user_patient_profile[:patient_profile]=patient_profile
-        render json: user_patient_profile
-      else
-        render json: user_patient_profile.errors, status: 422
-      end
+    patient_profile = PatientProfile.new(patient_profile_params)
+    if patient_profile.save
+      render json: patient_profile
     else
-      render json: user_patient_profile.errors, status: 422
+      render json: { status: 400 }
     end
   end
 
   def update
-    user_patient_profile = {}
-    patient_profile ={"patient_profile"=>"user is docter"}
-    user = User.find(user_params[:id])
-    if user.update(image: user_params[:image])
-      if user_params[:patient_or_doctor] == true
-        patient_profile = PatientProfile.find_by(user_id:patient_profile_params[:user_id])
-        if patient_profile.update(patient_profile_params)
-          user_patient_profile[:user]=user
-          user_patient_profile[:patient_profile]=patient_profile
-          render json: user_patient_profile
-        else
-          render json: user_patient_profile.errors, status: 422
-        end
-      else
-        user_patient_profile[:user]=user
-        user_patient_profile[:patient_profile]=patient_profile
-        render json: user_patient_profile
-      end
+    patient_profile = PatientProfile.find_by(user_id: patient_profile_params[:user_id])
+    if patient_profile.update(patient_profile_params)
+      render json: patient_profile
     else
-      render json: user_patient_profile.errors, status: 422
+      render json: { status: 400 }
     end
   end
 
   private
     def patient_profile_params
       params.require(:patient_profile).permit(
-        :room_number, :phone_number, :emergency_address, :address, :building, :user_id
-      )
-    end
-    def user_params
-      params.require(:user).permit(
-        :id, :patient_or_doctor, :image
-      )
+        :image, :room_number, :phone_number, :emergency_address, :address, :building, :user_id
+      ).merge(user_id: current_api_v1_user.id)
     end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+        :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
   has_one :patient_profile, dependent: :destroy

--- a/backend/config/initializers/devise_token_auth.rb
+++ b/backend/config/initializers/devise_token_auth.rb
@@ -5,7 +5,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.

--- a/backend/config/initializers/devise_token_auth.rb
+++ b/backend/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = true
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
       }
       
       namespace :auth do
-        resource :sessions, only: %i[index]
+        resources :sessions, only: %i[index]
       end
       get 'patient_profiles/show'
       post 'patient_profiles/create'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,14 +25,14 @@ services:
       - "3001:3000"
     depends_on:
       - db
-  front:
-    build:
-      context: ./frontend/
-      dockerfile: Dockerfile
-    volumes:
-      - ./frontend/react-app:/usr/src/app
-    command: sh -c "yarn start"
-    ports:
-      - "3000:3000"
+  # front:
+  #   build:
+  #     context: ./frontend/
+  #     dockerfile: Dockerfile
+  #   volumes:
+  #     - ./frontend/react-app:/usr/src/app
+  #   command: sh -c "yarn start"
+  #   ports:
+  #     - "3000:3000"
 volumes:
   mysql-data:

--- a/frontend/react-app/src/App.tsx
+++ b/frontend/react-app/src/App.tsx
@@ -47,7 +47,7 @@ const App: React.FC = () => {
 
   useEffect(() => {
     handleGetCurrentUser()
-  }, [setCurrentUser])
+  }, [])
 
   return (
     <Router>


### PR DESCRIPTION
## やったこと

・devise token authでの連続リクエストの許可
・backendにapiを送る際にuser情報はtokenを使うように仕様を変更したのでそれに対応した処理に書き換えた。

## やらないこと

interviewの処理の書き換え。
後でissueに追加する。

## できるようになること（ユーザ目線）

apiで送っていた不要なデータを減らす事ができたのと
devise token authで連続リクエストの制限はかなり重い処理のようで、
多少なりパフォーマンスが上がった

## できなくなること（ユーザ目線）

現在は特にないが、連続リクエストを制限したいと考えたとき、
例えば連続で問診が作成できなくする必要があった時に
別で処理を考えなければならない。

## 動作確認

動作確認は全てpostmanを使用。
frontから受け取るapiのjsonの中身もpostman上に保存してある。

## その他

特に無し。
