### PR TITLE
Front mypage: viewの作成とデータ表示のための処理作成

### DIFF
--- a/frontend/react-app/src/App.tsx
+++ b/frontend/react-app/src/App.tsx
@@ -5,6 +5,7 @@ import CommonLayout from "components/layouts/CommonLayout"
 import Home from "components/pages/Home"
 import SignUp from "components/pages/SignUp"
 import SignIn from "components/pages/SignIn"
+import Mypage from "components/pages/Mypage"
 
 import { getCurrentUser } from "lib/api/auth"
 import { User } from "interfaces/index"
@@ -57,6 +58,7 @@ const App: React.FC = () => {
             <Route path="/signup" element={<SignUp />} />
             <Route path="/signin" element={<SignIn />} />
             <Route path="/" element={<Home />} />
+            <Route path="/mypage" element={<Mypage />} />
           </Routes>
         </CommonLayout>
       </AuthContext.Provider>

--- a/frontend/react-app/src/App.tsx
+++ b/frontend/react-app/src/App.tsx
@@ -55,9 +55,9 @@ const App: React.FC = () => {
       <AuthContext.Provider value={{ loading, setLoading, isSignedIn, setIsSignedIn, currentUser, setCurrentUser }}>
         <CommonLayout>
           <Routes>
+            <Route path="/" element={<Home />} />
             <Route path="/signup" element={<SignUp />} />
             <Route path="/signin" element={<SignIn />} />
-            <Route path="/" element={<Home />} />
             <Route path="/mypage" element={<Mypage />} />
           </Routes>
         </CommonLayout>

--- a/frontend/react-app/src/App.tsx
+++ b/frontend/react-app/src/App.tsx
@@ -25,6 +25,14 @@ const App: React.FC = () => {
   const [isSignedIn, setIsSignedIn] = useState<boolean>(false)
   const [currentUser, setCurrentUser] = useState<User | undefined>()
 
+  const LoginCheck = ({ component }: { component: JSX.Element }): JSX.Element => {
+    if (isSignedIn) {
+      return <>{component}</>
+    } else {
+      return <Home />
+    }
+  }
+
   // 認証済みのユーザーがいるかどうかチェック
   // 確認できた場合はそのユーザーの情報を取得
   const handleGetCurrentUser = async () => {
@@ -58,7 +66,7 @@ const App: React.FC = () => {
             <Route path="/" element={<Home />} />
             <Route path="/signup" element={<SignUp />} />
             <Route path="/signin" element={<SignIn />} />
-            <Route path="/mypage" element={<Mypage />} />
+            <Route path="/mypage" element={LoginCheck({ component: <Mypage /> })} />
           </Routes>
         </CommonLayout>
       </AuthContext.Provider>

--- a/frontend/react-app/src/components/layouts/CommonLayout.tsx
+++ b/frontend/react-app/src/components/layouts/CommonLayout.tsx
@@ -4,10 +4,12 @@ import { Container, Grid } from "@material-ui/core"
 import { makeStyles } from "@material-ui/core/styles"
 
 import Header from "components/layouts/header/Header"
+import Footer from "components/layouts/footer/Footer"
 
 const useStyles = makeStyles(() => ({
   container: {
-    marginTop: "3rem"
+    marginTop: "5rem",
+    marginBottom: "10rem"
   }
 }))
 
@@ -33,6 +35,9 @@ const CommonLayout = ({ children }: CommonLayoutProps) => {
           </Grid>
         </Container>
       </main>
+      <footer>
+        <Footer />
+      </footer>
     </>
   )
 }

--- a/frontend/react-app/src/components/layouts/footer/Footer.tsx
+++ b/frontend/react-app/src/components/layouts/footer/Footer.tsx
@@ -1,0 +1,53 @@
+import React from "react"
+import { makeStyles, Theme } from '@material-ui/core/styles'
+import BottomNavigation from '@material-ui/core/BottomNavigation'
+import BottomNavigationAction from '@material-ui/core/BottomNavigationAction'
+import GitHubIcon from '@material-ui/icons/GitHub'
+import ContactMailIcon from '@material-ui/icons/ContactMail'
+// 自作パレット
+import { theme } from "styles/layouts/Style"
+import { ThemeProvider } from "@material-ui/styles"
+
+const useStyles = makeStyles((theme: Theme) => ({
+  footerStyle: {
+    display: 'flex',
+    flexDirection: 'column',
+    marginTop: 10,
+    height: 145,
+    justifyContent: 'space-between',
+    backgroundColor: 'primary',
+    position: "static",
+  },
+  copyRight: {
+    marginTop: 10,
+    marginBottom: 15,
+    textAlign: 'center',
+  }
+}))
+
+const Footer: React.FC = () => {
+  const classes = useStyles();
+  const [value, setValue] = React.useState(0);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <div className={classes.footerStyle}>
+        <BottomNavigation
+          value={value}
+          onChange={(event, newValue) => {
+            setValue(newValue);
+          }}
+          showLabels
+        >
+          <BottomNavigationAction label="GitHub" icon={<GitHubIcon />} />
+          <BottomNavigationAction label="SendMail" icon={<ContactMailIcon />} />
+        </BottomNavigation>
+        <div className={classes.copyRight}>
+          Copyright © Website 2022 Akira Takano All rights reserved.
+        </div>
+      </div>
+    </ThemeProvider>
+  )
+}
+
+export default Footer

--- a/frontend/react-app/src/components/layouts/header/Button.tsx
+++ b/frontend/react-app/src/components/layouts/header/Button.tsx
@@ -11,13 +11,23 @@ export const AuthButtons = ({ classes, handleSignOut }: any) => {
   if (!loading) {
     if (isSignedIn) {
       return (
-        <Button
-          color="inherit"
-          className={classes.linkBtn}
-          onClick={handleSignOut}
-        >
-          Sign out
-        </Button>
+        <>
+          <Button
+            component={Link}
+            to="/mypage"
+            color="inherit"
+            className={classes.linkBtn}
+          >
+            My Page
+          </Button>
+          <Button
+            color="inherit"
+            className={classes.linkBtn}
+            onClick={handleSignOut}
+          >
+            Sign out
+          </Button>
+        </>
       )
     } else {
       return (

--- a/frontend/react-app/src/components/layouts/header/Header.tsx
+++ b/frontend/react-app/src/components/layouts/header/Header.tsx
@@ -51,7 +51,7 @@ const Header: React.FC = () => {
         Cookies.remove("_uid")
 
         setIsSignedIn(false)
-        navigate("/signin")
+        navigate("/")
 
         console.log("Succeeded in sign out")
       } else {

--- a/frontend/react-app/src/components/pages/Home.tsx
+++ b/frontend/react-app/src/components/pages/Home.tsx
@@ -1,41 +1,10 @@
-import React, { useContext } from "react"
-import { Navigate } from "react-router-dom"
+import React from "react"
 
-import { AuthContext } from "App"
-
-// とりあえず認証済みユーザーの名前やメールアドレスを表示
 const Home: React.FC = () => {
-  const { isSignedIn, currentUser, loading } = useContext(AuthContext);
-
-  // ユーザーが認証済みかどうかでルーティングを決定
-  // 未認証だった場合は「/signin」ページに促す
-  const Private = ({ children }: { children: React.ReactElement }) => {
-    if (!loading) {
-      if (isSignedIn) {
-        return children
-      } else {
-        return <Navigate to="/signin" />
-      }
-    } else {
-      return <></>
-    }
-  }
 
   return (
     <>
-      {
-        isSignedIn && currentUser ? (
-          <Private>
-            <>
-              <h1>Signed in successfully!</h1>
-              <h2>Email: {currentUser?.email}</h2>
-              <h2>Name: {currentUser?.name}</h2>
-            </>
-          </Private>
-        ) : (
-          <h1>Not signed in</h1>
-        )
-      }
+      <h1>Not signed in</h1>
     </>
   )
 }

--- a/frontend/react-app/src/components/pages/Mypage.tsx
+++ b/frontend/react-app/src/components/pages/Mypage.tsx
@@ -1,0 +1,10 @@
+import React, { useState, useContext } from "react"
+import { AuthContext } from "App"
+
+const Mypage: React.FC = () => {
+
+  return (
+    <div></div>
+  )
+}
+export default Mypage

--- a/frontend/react-app/src/components/pages/Mypage.tsx
+++ b/frontend/react-app/src/components/pages/Mypage.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect, useContext } from "react"
-import { Navigate } from "react-router-dom"
 import { AuthContext } from "App"
-
 // mui
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles'
 import Card from '@material-ui/core/Card'
@@ -11,13 +9,13 @@ import Button from '@material-ui/core/Button'
 import Typography from '@material-ui/core/Typography'
 import Grid from '@material-ui/core/Grid'
 import Avatar from '@material-ui/core/Avatar'
-
+import { pink } from '@material-ui/core/colors'
+import LocalHospitalIcon from '@material-ui/icons/LocalHospital'
 // 自作パレット
 import { theme } from "styles/layouts/Style"
 import { ThemeProvider } from "@material-ui/styles"
-
+// api取得
 import { patientShow } from "lib/api/auth"
-// import { PatientParams } from "interfaces/index"
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -36,19 +34,33 @@ const useStyles = makeStyles((theme: Theme) =>
     large: {
       width: theme.spacing(7),
       height: theme.spacing(7),
-      marginBottom: 50
+      marginBottom: 30
+    },
+    pink: {
+      color: theme.palette.getContrastText(pink[500]),
+      backgroundColor: pink[100],
     },
     cardContent: {
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center'
+    },
+    cardActions: {
+      display: 'flex',
+      justifyContent: 'center'
+    },
+    button: {
+      size: "large",
+      backgroundColor: pink[100],
+      variant: "contained",
+      marginTop: 20
     }
   }),
 );
 
 
 const Mypage: React.FC = () => {
-  const { isSignedIn, currentUser, loading } = useContext(AuthContext);
+  const { currentUser } = useContext(AuthContext);
   const [image, setImage] = useState<string>("")
   const [roomNumber, setRoomNumber] = useState<number>(0)
   const [phoneNumber, setPhoneNumber] = useState<string>("")
@@ -61,7 +73,7 @@ const Mypage: React.FC = () => {
       const res = await patientShow()
       if (res.data.roomNumber) {
         console.log(res)
-        setImage(res?.data.image)
+        setImage(res?.data.image.url)
         setRoomNumber(res?.data.roomNumber)
         setPhoneNumber(res?.data.phoneNumber)
         setEmergencyAddress(res?.data.emergencyAddress)
@@ -69,7 +81,7 @@ const Mypage: React.FC = () => {
         setBuilding(res?.data.building)
         console.log("get patientprofile")
       } else {
-        console.log("Failed in get patientprofile")
+        console.log("user is doctor")
       }
     } catch (err) {
       console.log(err)
@@ -80,113 +92,83 @@ const Mypage: React.FC = () => {
     getProfils()
   }, [])
 
-  // // ユーザーが認証済みかどうかでルーティングを決定
-  // 未認証だった場合は「/signin」ページに促す
-  const Private = ({ children }: { children: React.ReactElement }) => {
-    if (!loading) {
-      if (isSignedIn) {
-        return children
-      } else {
-        return <Navigate to="/signin" />
-      }
-    } else {
-      return <></>
-    }
-  }
-
   const classes = useStyles();
 
   return (
     <ThemeProvider theme={theme}>
-      <Private>
-        <Grid container spacing={3}>
+      <Grid container spacing={3}>
+        <Grid item xs={12} sm={6}>
+          <Card className={classes.cardRoot}>
+            <CardContent className={classes.cardContent}>
+              {currentUser?.patientOrDoctor ?
+                <Avatar alt="Remy Sharp" src={image} className={classes.large} />
+                :
+                <Avatar className={classes.pink}>
+                  <LocalHospitalIcon />
+                </Avatar>
+              }
+              <Typography variant="h5" component="h2" style={{ marginBottom: 30 }} >
+                {currentUser?.name}
+              </Typography>
+              <Typography className={classes.pos}>
+                メールアドレス {currentUser?.email}
+              </Typography>
+              {currentUser?.sex ?
+                <Typography className={classes.pos}>
+                  性別 男性
+                </Typography>
+                :
+                <Typography className={classes.pos}>
+                  性別 女性
+                </Typography>
+              }
+            </CardContent>
+            {currentUser?.patientOrDoctor ||
+              <CardActions className={classes.cardActions}>
+                <Button
+                  color="primary"
+                  size="large"
+                  variant="contained"
+                >
+                  患者様一覧
+                </Button>
+              </CardActions>
+            }
+          </Card>
+        </Grid>
+        {currentUser?.patientOrDoctor &&
           <Grid item xs={12} sm={6}>
             <Card className={classes.cardRoot}>
               <CardContent className={classes.cardContent}>
-                {currentUser?.patientOrDoctor &&
-                  <Avatar alt="Remy Sharp" className={classes.large} />
-                }
-                <Typography variant="h5" component="h2" style={{ marginBottom: 30 }}>
-                  {currentUser?.name}
+                <Typography variant="h5" component="h2" style={{ marginBottom: 20 }}>
+                  患者様情報
                 </Typography>
                 <Typography className={classes.pos}>
-                  メールアドレス {currentUser?.email}
+                  部屋番号 {roomNumber}
                 </Typography>
-                {currentUser?.sex ?
-                  <Typography className={classes.pos}>
-                    性別 男性
-                  </Typography>
-                  :
-                  <Typography className={classes.pos}>
-                    性別 女性
-                  </Typography>
-                }
+                <Typography className={classes.pos}>
+                  電話番号 {phoneNumber}
+                </Typography>
+                <Typography className={classes.pos}>
+                  緊急連絡先 {emergencyAddress}
+                </Typography>
+                <Typography className={classes.pos}>
+                  住所 {address}{building}
+                </Typography>
+                <CardActions>
+                  <Button className={classes.button}>
+                    編集
+                  </Button>
+                  <Button className={classes.button}>
+                    問診
+                  </Button>
+                </CardActions>
               </CardContent>
             </Card>
           </Grid>
-          {currentUser?.patientOrDoctor ?
-            <Grid item xs={12} sm={6}>
-              <Card className={classes.cardRoot}>
-                <CardContent className={classes.cardContent}>
-                  <Typography variant="h5" component="h2" style={{ marginBottom: 20 }}>
-                    患者様情報
-                  </Typography>
-                  <Typography className={classes.pos}>
-                    部屋番号 {roomNumber}
-                  </Typography>
-                  <Typography className={classes.pos}>
-                    電話番号 {phoneNumber}
-                  </Typography>
-                  <Typography className={classes.pos}>
-                    緊急連絡先 {emergencyAddress}
-                  </Typography>
-                  <Typography className={classes.pos}>
-                    住所 {address}{building}
-                  </Typography>
-                  <CardActions>
-                    <Button
-                      size="large"
-                      color="primary"
-                      variant="contained"
-                      style={{ marginTop: 20 }}
-                    >
-                      編集
-                    </Button>
-                    <Button
-                      size="large"
-                      color="primary"
-                      variant="contained"
-                      style={{ marginTop: 20 }}
-                    >
-                      問診
-                    </Button>
-                  </CardActions>
-                </CardContent>
-              </Card>
-            </Grid>
-            :
-            <Grid item xs={12} sm={6}>
-              <Card className={classes.cardRoot}>
-                <CardContent>
-                  <Typography variant="h5" component="h2">
-                    医療
-                  </Typography>
-                </CardContent>
-                <CardActions>
-                  <Button
-                    color="default"
-                    size="small"
-                    variant="contained"
-                  >
-                    Learn More
-                  </Button>
-                </CardActions>
-              </Card>
-            </Grid>
-          }
-        </Grid>
-      </Private>
-    </ThemeProvider>
+        }
+      </Grid>
+    </ThemeProvider >
   )
 }
 export default Mypage

--- a/frontend/react-app/src/components/pages/Mypage.tsx
+++ b/frontend/react-app/src/components/pages/Mypage.tsx
@@ -1,7 +1,22 @@
 import React, { useState, useContext } from "react"
+import { Navigate } from "react-router-dom"
 import { AuthContext } from "App"
 
 const Mypage: React.FC = () => {
+  const { isSignedIn, currentUser, loading } = useContext(AuthContext);
+  // ユーザーが認証済みかどうかでルーティングを決定
+  // 未認証だった場合は「/signin」ページに促す
+  const Private = ({ children }: { children: React.ReactElement }) => {
+    if (!loading) {
+      if (isSignedIn) {
+        return children
+      } else {
+        return <Navigate to="/signin" />
+      }
+    } else {
+      return <></>
+    }
+  }
 
   return (
     <div></div>

--- a/frontend/react-app/src/components/pages/Mypage.tsx
+++ b/frontend/react-app/src/components/pages/Mypage.tsx
@@ -1,10 +1,86 @@
-import React, { useState, useContext } from "react"
+import React, { useState, useEffect, useContext } from "react"
 import { Navigate } from "react-router-dom"
 import { AuthContext } from "App"
 
+// mui
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles'
+import Card from '@material-ui/core/Card'
+import CardActions from '@material-ui/core/CardActions'
+import CardContent from '@material-ui/core/CardContent'
+import Button from '@material-ui/core/Button'
+import Typography from '@material-ui/core/Typography'
+import Grid from '@material-ui/core/Grid'
+import Avatar from '@material-ui/core/Avatar'
+
+// 自作パレット
+import { theme } from "styles/layouts/Style"
+import { ThemeProvider } from "@material-ui/styles"
+
+import { patientShow } from "lib/api/auth"
+// import { PatientParams } from "interfaces/index"
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    cardRoot: {
+      minWidth: 320,
+      height: 350
+    },
+    bullet: {
+      display: 'inline-block',
+      margin: '0 2px',
+      transform: 'scale(0.8)',
+    },
+    pos: {
+      marginBottom: 12,
+    },
+    large: {
+      width: theme.spacing(7),
+      height: theme.spacing(7),
+      marginBottom: 50
+    },
+    cardContent: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center'
+    }
+  }),
+);
+
+
 const Mypage: React.FC = () => {
   const { isSignedIn, currentUser, loading } = useContext(AuthContext);
-  // ユーザーが認証済みかどうかでルーティングを決定
+  const [image, setImage] = useState<string>("")
+  const [roomNumber, setRoomNumber] = useState<number>(0)
+  const [phoneNumber, setPhoneNumber] = useState<string>("")
+  const [emergencyAddress, setEmergencyAddress] = useState<string>("")
+  const [address, setAddress] = useState<string>("")
+  const [building, setBuilding] = useState<string>("")
+
+  const getProfils = async () => {
+    try {
+      const res = await patientShow()
+      if (res.data.roomNumber) {
+        console.log(res)
+        setImage(res?.data.image)
+        setRoomNumber(res?.data.roomNumber)
+        setPhoneNumber(res?.data.phoneNumber)
+        setEmergencyAddress(res?.data.emergencyAddress)
+        setAddress(res?.data.address)
+        setBuilding(res?.data.building)
+        console.log("get patientprofile")
+      } else {
+        console.log("Failed in get patientprofile")
+      }
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  useEffect(() => {
+    getProfils()
+  }, [])
+
+  // // ユーザーが認証済みかどうかでルーティングを決定
   // 未認証だった場合は「/signin」ページに促す
   const Private = ({ children }: { children: React.ReactElement }) => {
     if (!loading) {
@@ -18,8 +94,99 @@ const Mypage: React.FC = () => {
     }
   }
 
+  const classes = useStyles();
+
   return (
-    <div></div>
+    <ThemeProvider theme={theme}>
+      <Private>
+        <Grid container spacing={3}>
+          <Grid item xs={12} sm={6}>
+            <Card className={classes.cardRoot}>
+              <CardContent className={classes.cardContent}>
+                {currentUser?.patientOrDoctor &&
+                  <Avatar alt="Remy Sharp" className={classes.large} />
+                }
+                <Typography variant="h5" component="h2" style={{ marginBottom: 30 }}>
+                  {currentUser?.name}
+                </Typography>
+                <Typography className={classes.pos}>
+                  メールアドレス {currentUser?.email}
+                </Typography>
+                {currentUser?.sex ?
+                  <Typography className={classes.pos}>
+                    性別 男性
+                  </Typography>
+                  :
+                  <Typography className={classes.pos}>
+                    性別 女性
+                  </Typography>
+                }
+              </CardContent>
+            </Card>
+          </Grid>
+          {currentUser?.patientOrDoctor ?
+            <Grid item xs={12} sm={6}>
+              <Card className={classes.cardRoot}>
+                <CardContent className={classes.cardContent}>
+                  <Typography variant="h5" component="h2" style={{ marginBottom: 20 }}>
+                    患者様情報
+                  </Typography>
+                  <Typography className={classes.pos}>
+                    部屋番号 {roomNumber}
+                  </Typography>
+                  <Typography className={classes.pos}>
+                    電話番号 {phoneNumber}
+                  </Typography>
+                  <Typography className={classes.pos}>
+                    緊急連絡先 {emergencyAddress}
+                  </Typography>
+                  <Typography className={classes.pos}>
+                    住所 {address}{building}
+                  </Typography>
+                  <CardActions>
+                    <Button
+                      size="large"
+                      color="primary"
+                      variant="contained"
+                      style={{ marginTop: 20 }}
+                    >
+                      編集
+                    </Button>
+                    <Button
+                      size="large"
+                      color="primary"
+                      variant="contained"
+                      style={{ marginTop: 20 }}
+                    >
+                      問診
+                    </Button>
+                  </CardActions>
+                </CardContent>
+              </Card>
+            </Grid>
+            :
+            <Grid item xs={12} sm={6}>
+              <Card className={classes.cardRoot}>
+                <CardContent>
+                  <Typography variant="h5" component="h2">
+                    医療
+                  </Typography>
+                </CardContent>
+                <CardActions>
+                  <Button
+                    color="default"
+                    size="small"
+                    variant="contained"
+                  >
+                    Learn More
+                  </Button>
+                </CardActions>
+              </Card>
+            </Grid>
+          }
+        </Grid>
+      </Private>
+    </ThemeProvider>
   )
 }
 export default Mypage

--- a/frontend/react-app/src/components/pages/SignIn.tsx
+++ b/frontend/react-app/src/components/pages/SignIn.tsx
@@ -72,7 +72,7 @@ const SignIn: React.FC = () => {
         setIsSignedIn(true)
         setCurrentUser(res.data.data)
 
-        navigate("/")
+        navigate("/mypage")
 
         console.log("Signed in successfully!")
       } else {

--- a/frontend/react-app/src/components/pages/SignIn.tsx
+++ b/frontend/react-app/src/components/pages/SignIn.tsx
@@ -105,7 +105,7 @@ const SignIn: React.FC = () => {
               fullWidth
               label="パスワード"
               type="password"
-              placeholder="At least 6 characters"
+              placeholder="6文字以上入力してください"
               value={password}
               margin="dense"
               autoComplete="current-password"

--- a/frontend/react-app/src/components/pages/SignUp.tsx
+++ b/frontend/react-app/src/components/pages/SignUp.tsx
@@ -100,7 +100,7 @@ const SignUp: React.FC = () => {
         setIsSignedIn(true)
         setCurrentUser(res.data.data)
 
-        navigate("/")
+        navigate("/Mypage")
 
         console.log("Signed in successfully!")
       } else {

--- a/frontend/react-app/src/interfaces/index.ts
+++ b/frontend/react-app/src/interfaces/index.ts
@@ -31,6 +31,8 @@ export interface User {
   provider: string
   email: string
   name: string
+  patientOrDoctor: boolean
+  sex: boolean
   allowPasswordChange: boolean
   created_at: Date
   updated_at: Date

--- a/frontend/react-app/src/interfaces/index.ts
+++ b/frontend/react-app/src/interfaces/index.ts
@@ -1,25 +1,12 @@
 // サインアップ
 export interface SignUpParams {
-
   name: string
   email: string
   password: string
   passwordConfirmation: string
   patientOrDoctor: boolean | undefined
   sex: boolean | undefined
-  // patient
-  // patientProfile: PatientParams
-
 }
-
-// export interface PatientParams {
-//   // patient
-//   roomNumber: number
-//   phoneNumber: string
-//   emergencyAddress: string
-//   address: string
-//   building: string
-// }
 
 // サインイン
 export interface SignInParams {
@@ -27,15 +14,23 @@ export interface SignInParams {
   password: string
 }
 
-// ユーザー
+// 患者様情報
+export interface PatientParams {
+  image: string
+  roomNumber: number
+  phoneNumber: string
+  emergencyAddress: string
+  address: string
+  building: string
+}
+
+// ユーザー cookie
 export interface User {
   id: number
   uid: string
   provider: string
   email: string
   name: string
-  nickname?: string
-  image?: string
   allowPasswordChange: boolean
   created_at: Date
   updated_at: Date

--- a/frontend/react-app/src/lib/api/auth.ts
+++ b/frontend/react-app/src/lib/api/auth.ts
@@ -36,3 +36,12 @@ export const getCurrentUser = () => {
   })
 }
 
+export const patientShow = () => {
+  return client.get("/patient_profiles/show", {
+    headers: {
+      "access-token": Cookies.get("_access_token")!,
+      "client": Cookies.get("_client")!,
+      "uid": Cookies.get("_uid")!
+    }
+  })
+}


### PR DESCRIPTION
## やったこと

・mypageのviewの作成
・dbからデータの取得、表示
・ユーザーの種類を元に表示切り替え
・未認証時のhomeへのリダイレクト

## やらないこと

・マテリアルuiの使用によるpropsの受け渡しエラーは保留
エラーが吐かれるだけでシステムに問題はないので後回しreact自体の理解が深まったら手を付ける
・mypageからの遷移
遷移先のページができてから手を付ける

## できるようになること（ユーザ目線）

・mypageの利用
患者様、医療従事者共に。

## できなくなること（ユーザ目線）

・未認証時にhome以外のページへの遷移

## 動作確認

・直接viewを確認して動きを確認
コンソールにエラーが出るが上記マテリアルUI関係なので保留

## その他

プライベートでやっていた処理ををlogincheckに任せたので新規ページにリダイレクトをつける必要なし。
