### PR TITLE
問診一覧必要データ取得 ページネーション準備 ユーザー別取得データ #34

### DIFF
--- a/frontend/react-app/src/App.tsx
+++ b/frontend/react-app/src/App.tsx
@@ -8,6 +8,7 @@ import SignIn from "components/pages/SignIn"
 import Mypage from "components/pages/Mypage"
 import Patients from "components/pages/Patients"
 import Patient from "components/pages/Patient"
+import Interviews from "components/pages/Interviews"
 
 import { getCurrentUser } from "lib/api/auth"
 import { User } from "interfaces/index"
@@ -68,6 +69,7 @@ const App: React.FC = () => {
             <Route path="/mypage" element={LoginCheck({ component: <Mypage /> })} />
             <Route path="/patients" element={LoginCheck({ component: <Patients /> })} />
             <Route path="/patient/:id" element={LoginCheck({ component: <Patient /> })} />
+            <Route path="/interviews/:id" element={LoginCheck({ component: <Interviews /> })} />
           </Routes>
         </CommonLayout>
       </AuthContext.Provider>

--- a/frontend/react-app/src/components/pages/Interviews.tsx
+++ b/frontend/react-app/src/components/pages/Interviews.tsx
@@ -1,0 +1,60 @@
+import React, { useContext, useState, useEffect } from "react"
+import { AuthContext } from "App"
+import { useNavigate, useParams } from "react-router-dom"
+
+import { InterviewsIndex } from "interfaces/interview"
+import { interviewsIndex, interviewsIndexUser } from "lib/api/auth"
+
+const Interviews: React.FC = () => {
+  const { currentUser } = useContext(AuthContext)
+  const [interviews, setInterviews] = useState<InterviewsIndex[]>([])
+  const [page, setPage] = useState<number>(1)
+  const [pageCount, setPageCount] = useState<number>()
+  const [displayedUsers, setDisplayedUsers] = useState<InterviewsIndex[]>([])
+  const displayNum = 5;
+  const navigate = useNavigate()
+  const query = useParams();
+  console.log(interviews)
+
+  const saveInterviews = (res: InterviewsIndex[]) => {
+    if (res) {
+      setInterviews(res)
+      console.log("get interviews")
+    } else {
+      console.log("Failed to get the interviews")
+    }
+  }
+  const getInterviews = async (query: any) => {
+    try {
+      if (currentUser?.patientOrDoctor) {
+        const res = await interviewsIndex()
+        saveInterviews(res.data)
+      } else {
+        const res = await interviewsIndexUser(query.id)
+        saveInterviews(res.data)
+      }
+
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  useEffect(() => {
+    getInterviews(query)
+  }, [query])
+  useEffect(() => {
+    setPageCount(Math.ceil(interviews.length / displayNum))
+    setDisplayedUsers(interviews.slice(((page - 1) * displayNum), page * displayNum))
+  }, [interviews])
+
+  const handleChange = (event: React.ChangeEvent<unknown>, index: number) => {
+    setPage(index);
+    setDisplayedUsers(interviews.slice(((index - 1) * displayNum), index * displayNum))
+  }
+
+  return (
+    <></>
+  )
+}
+
+export default Interviews

--- a/frontend/react-app/src/components/pages/Patients.tsx
+++ b/frontend/react-app/src/components/pages/Patients.tsx
@@ -134,7 +134,6 @@ const Patients: React.FC = memo(() => {
   useEffect(() => {
     getUsers()
   }, [])
-
   useEffect(() => {
     setPageCount(Math.ceil(users.length / displayNum))
     setDisplayedUsers(users.slice(((page - 1) * displayNum), page * displayNum))

--- a/frontend/react-app/src/interfaces/interview.ts
+++ b/frontend/react-app/src/interfaces/interview.ts
@@ -1,0 +1,10 @@
+export interface InterviewsIndex {
+  id: number
+  temperature: number
+  oxygenSaturation: number
+  instrumentationTime: Date
+  status: number
+  other: boolean
+  userId: number
+  created_at: Date
+}

--- a/frontend/react-app/src/lib/api/auth.ts
+++ b/frontend/react-app/src/lib/api/auth.ts
@@ -65,3 +65,23 @@ export const userShow = (id: number) => {
     }
   })
 }
+
+export const interviewsIndex = () => {
+  return client.get("/interviews/index", {
+    headers: {
+      "access-token": Cookies.get("_access_token")!,
+      "client": Cookies.get("_client")!,
+      "uid": Cookies.get("_uid")!
+    }
+  })
+}
+
+export const interviewsIndexUser = (id: number) => {
+  return client.get(`/interviews/index?id=${id}`, {
+    headers: {
+      "access-token": Cookies.get("_access_token")!,
+      "client": Cookies.get("_client")!,
+      "uid": Cookies.get("_uid")!
+    }
+  })
+}


### PR DESCRIPTION
## やったこと

・interviews/indexにおいて必要なデータの取得stateの準備
・interviews/indexからshowへの遷移

## やらないこと

・viewの作成
・取得したデータでの処理

## できるようになること（ユーザ目線）

・interviews/indexへの遷移

## できなくなること（ユーザ目線）

無し

## 動作確認

・console.logを使ったデバッグ

## その他

無し
